### PR TITLE
修复可能的内存泄露问题

### DIFF
--- a/lib/formatter.js
+++ b/lib/formatter.js
@@ -104,18 +104,18 @@ Formatter.prototype.exec = function (cliOptions) {
                 return;
             }
 
-            var contents = file.contents.toString();
-
-            var done = function (contents) {
-                file.contents = new Buffer(contents);
-                cb(null, file);
-                formatter.removeListener('error', errorCallback);
-            };
-
             var self = this;
+
+            var contents = file.contents.toString();
 
             var errorCallback = function (error) {
                 self.emit('error', error);
+            };
+
+            var done = function (contents) {
+                file.contents = new Buffer(contents);
+                formatter.removeListener('error', errorCallback);
+                cb(null, file);
             };
 
             formatter.once('error', errorCallback);

--- a/lib/formatter.js
+++ b/lib/formatter.js
@@ -109,12 +109,16 @@ Formatter.prototype.exec = function (cliOptions) {
             var done = function (contents) {
                 file.contents = new Buffer(contents);
                 cb(null, file);
+                formatter.removeListener('error', errorCallback);
             };
 
             var self = this;
-            formatter.once('error', function (error) {
+
+            var errorCallback = function (error) {
                 self.emit('error', error);
-            });
+            };
+
+            formatter.once('error', errorCallback);
 
             // callback style
             if (formatter.format.length > 3) {


### PR DESCRIPTION
格式化多个文件时报了个警告，possible EventEmitter memory leak detected. 11 error listeners added. Use emitter.setMaxListeners() to increase limit.