### PR TITLE
完善在 reporter baidu 情况下，no-require 的报错级别及规范信息

### DIFF
--- a/lib/js/rules/valid-jsdoc.js
+++ b/lib/js/rules/valid-jsdoc.js
@@ -584,7 +584,7 @@ module.exports = function (context) {
             if (
                 tag
                 && name
-                && name !== tag.name.replace(/^.+\.(?=[^\.]+)/, '')
+                && (tag.name && name !== tag.name.replace(/^.+\.(?=[^\.]+)/, ''))
             ) {
                 var row = params[jsdocParam].lineNumber;
                 var col = (lines[row] + '').indexOf(jsdocParam);

--- a/lib/reporter/baidu/es-next.yml
+++ b/lib/reporter/baidu/es-next.yml
@@ -160,4 +160,6 @@
 654:
   level: 1
   desc: "[建议] AMD/CommonJS 模块依赖 ESNext 模块时，AMD/CommonJS 模块对 default export 的 require 需要改造。"
-
+655:
+  level: 1
+  desc: "[建议] ESNext 的文件中，不要使用 `require`。"

--- a/lib/reporter/baidu/eslint-map.yml
+++ b/lib/reporter/baidu/eslint-map.yml
@@ -41,6 +41,8 @@ fecs-valid-constructor: "110,111"
 fecs-valid-dom-style: "137,138"
 fecs-use-async-require: "128"
 
+fecs-no-require: "655"
+
 babel/generator-star-spacing: "604"
 babel/new-cap: "027,029,030"
 babel/array-bracket-spacing: "012"

--- a/lib/reporter/baidu/index.js
+++ b/lib/reporter/baidu/index.js
@@ -202,6 +202,12 @@ var baidu = {
             var origin = error.origin;
 
             return origin.nodeType === 'Literal' ? '138' : '137';
+        },
+
+        'fecs-no-require': function (error) {
+            var origin = error.origin;
+
+            return origin.nodeType === 'CallExpression' ? '655' : '998';
         }
 
     },

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "coverage": "istanbul cover ./node_modules/jasmine-node/bin/jasmine-node -x \"{cli,lib/css/rules}/*.js\" --captureExceptions test/",
     "test": "npm run lint && npm run coverage",
     "coveralls": "cat ./coverage/lcov.info | coveralls",
-    "postinstall": "node scripts/install.js"
+    "postinstall": "node scripts/install.js",
+    "coverage-single": "istanbul cover ./node_modules/jasmine-node/bin/jasmine-node -x \"{cli,lib/css/rules}/*.js\" --captureExceptions test/lib/util.spec.js"
   },
   "bin": {
     "fecs": "./bin/fecs"
@@ -42,7 +43,7 @@
   },
   "homepage": "https://github.com/ecomfe/fecs",
   "dependencies": {
-    "babel-eslint": "^6.1.2",
+    "babel-eslint": "6.1.2",
     "chalk": "^1.1.1",
     "csscomb": "^3.1.7",
     "csshint": "stable",

--- a/package.json
+++ b/package.json
@@ -8,8 +8,7 @@
     "coverage": "istanbul cover ./node_modules/jasmine-node/bin/jasmine-node -x \"{cli,lib/css/rules}/*.js\" --captureExceptions test/",
     "test": "npm run lint && npm run coverage",
     "coveralls": "cat ./coverage/lcov.info | coveralls",
-    "postinstall": "node scripts/install.js",
-    "coverage-single": "istanbul cover ./node_modules/jasmine-node/bin/jasmine-node -x \"{cli,lib/css/rules}/*.js\" --captureExceptions test/lib/js/rules/export-on-declare.spec.js"
+    "postinstall": "node scripts/install.js"
   },
   "bin": {
     "fecs": "./bin/fecs"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "test": "npm run lint && npm run coverage",
     "coveralls": "cat ./coverage/lcov.info | coveralls",
     "postinstall": "node scripts/install.js",
-    "coverage-single": "istanbul cover ./node_modules/jasmine-node/bin/jasmine-node -x \"{cli,lib/css/rules}/*.js\" --captureExceptions test/lib/util.spec.js"
+    "coverage-single": "istanbul cover ./node_modules/jasmine-node/bin/jasmine-node -x \"{cli,lib/css/rules}/*.js\" --captureExceptions test/lib/js/rules/export-on-declare.spec.js"
   },
   "bin": {
     "fecs": "./bin/fecs"
@@ -43,7 +43,7 @@
   },
   "homepage": "https://github.com/ecomfe/fecs",
   "dependencies": {
-    "babel-eslint": "6.1.2",
+    "babel-eslint": "^6.1.2",
     "chalk": "^1.1.1",
     "csscomb": "^3.1.7",
     "csshint": "stable",

--- a/test/lib/js/rules/export-on-declare.spec.js
+++ b/test/lib/js/rules/export-on-declare.spec.js
@@ -34,7 +34,6 @@ ruleTester.run('export-on-declare', rule, {
         'export default {foo, bar}',
         'export default class {}',
         'export class Foo {}',
-        // 'export new Foo();',
         'export default (function (foo) {return foo;})();',
         'export {a};',
         'export const foo = {a, bar};',

--- a/test/lib/js/rules/export-on-declare.spec.js
+++ b/test/lib/js/rules/export-on-declare.spec.js
@@ -34,7 +34,7 @@ ruleTester.run('export-on-declare', rule, {
         'export default {foo, bar}',
         'export default class {}',
         'export class Foo {}',
-        'export new Foo();',
+        // 'export new Foo();',
         'export default (function (foo) {return foo;})();',
         'export {a};',
         'export const foo = {a, bar};',

--- a/test/lib/js/rules/valid-jsdoc.spec.js
+++ b/test/lib/js/rules/valid-jsdoc.spec.js
@@ -39,6 +39,23 @@ ruleTester.run('valid-jsdoc', rule, {
         },
         {
             code: [
+                '/**',
+                ' * foo desc',
+                ' *',
+                ' * @param {Object} bar.foo desc',
+                ' */',
+                'function foo(bar) {}'
+            ].join('\n'),
+            options: [
+                {
+                    requireFileDescription: false,
+                    requireAuthor: false,
+                    requireReturn: false
+                }
+            ]
+        },
+        {
+            code: [
                 '/*foo-bar*/',
                 'function foo(bar) {}'
             ].join('\n'),


### PR DESCRIPTION
在百度编译机（即 reporter=baidu） 的情况下，很多人都会报 no-require 的问题，这是因为之前 no-require 并未写入 reporter baidu 的配置中，导致检测出这个错误就会按照 error 级别来处理。
本次修复了这个问题，请各位大大 review
@chriswong @otakustay @Justineo @erik168 