### PR TITLE
fix eslint config

### DIFF
--- a/lib/js/eslint.yml
+++ b/lib/js/eslint.yml
@@ -4,8 +4,6 @@ env:
   amd: true
   jasmine: true
   node: true
-  react: false
-  import: false
 globals:
   baidu: true
   bds: true
@@ -523,8 +521,8 @@ rules:
   import/extensions:
     - 2
     -
-      .js: never,
-      .jsx: never,
+      .js: never
+      .jsx: never
       .es: never
   import/order: 1
   import/newline-after-import: 2


### PR DESCRIPTION
写了一个[eslint-config-baidu-fecs](https://github.com/teazean/eslint-config-baidu-fecs)的eslint的配置，配置内容就是从`eslint.yml`转过来的，删除了一些fecs-*的rules，稍作修改（比如添加 indent），中间检查出来一些错误

1. `import/extensions`: 逗号没删除干净
2. `env`: `env`的值是从<https://eslint.org/docs/user-guide/configuring#specifying-environments>这里的枚举值，并且`eslint-plugin-react`、`eslint-plugin-import`也没定义`react`、`import`这两个值。带上这两个值执行失败，去掉就可以了。。




ps：这个`eslint-config-badiu-fecs`主要是给[vue-template-webpack](https://github.com/teazean/vue-template-webpack)用的，这个模板是一个符合百度代码规范的vue模板，方便组内同学使用。