### PR TITLE
fix: 修正postinstall钩子在 sudo模式下无权限的问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/ecomfe/fecs"
+    "url": "https://github.com/xtx1130/fecs"
   },
   "keywords": [
     "fecs",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/xtx1130/fecs"
+    "url": "https://github.com/ecomfe/fecs"
   },
   "keywords": [
     "fecs",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "coverage": "istanbul cover ./node_modules/jasmine-node/bin/jasmine-node -x \"{cli,lib/css/rules}/*.js\" --captureExceptions test/",
     "test": "npm run lint && npm run coverage",
     "coveralls": "cat ./coverage/lcov.info | coveralls",
-    "postinstall": "node scripts/install.js"
+    "postinstall": "node scripts/install.js --allow-root"
   },
   "bin": {
     "fecs": "./bin/fecs"


### PR DESCRIPTION
如果没给npm开通sudo权限的话，使用sudo安装的时候，postinstall会出现permission denied的问题。