### PR TITLE
add format codeframe

### DIFF
--- a/lib/formatter/codeframe.js
+++ b/lib/formatter/codeframe.js
@@ -1,0 +1,66 @@
+/**
+ * @file codeFrame formatter for check results
+ * @author Gavin<q414625852@163.com>
+ */
+
+const fs = require('fs');
+const path = require('path');
+const chalk = require("chalk");
+const codeFrame = require("babel-code-frame");
+
+const LEVEL_MAP = {
+    1: 'waring',
+    2: 'error'
+}
+
+const formatFilePath = (filePath, line, column) => {
+    if (line && column) {
+        filePath += `:${line}:${column}`;
+    }
+    return chalk.green(filePath);
+}
+
+const formatLevel = severity => {
+    const text = LEVEL_MAP[severity];
+    return severity === 1 ? chalk.yellow(text) : chalk.red(text);
+}
+
+const formatError = (path, sourceCode, error) => {
+    const {line, column, severity} = error;
+    const filePath = formatFilePath(path, line, column);
+    const level = formatLevel(severity);
+    const topMessage = `${level}: ${error.message} (${error.rule}) at ${filePath}:\n`;
+    return `${topMessage}${codeFrame(sourceCode, error.line, error.column)}`;
+}
+
+module.exports = function (json) {
+    let errors = 0;
+    let warings = 0;
+    let files = 0;
+    let output = [];
+
+    if (json.length) {
+
+        json.forEach(file => {
+            const sourceCode = fs.readFileSync(file.path, {encoding: 'utf-8'});
+            const path = file.relative;
+            const length = file.errors.length;
+            output.push(`fecs Linter found ${length} errors in file ${formatFilePath(path)}:\n`);
+            files++;
+            output = output.concat(file.errors.map(error => {
+                if (error.severity === 1) {
+                    warings++;
+                } else if (error.severity === 2) {
+                    errors++;
+                }
+                return `${formatError(path, sourceCode, error)}\n\n`
+            }));
+        });
+
+        // last result
+        output.push(`Result: ${errors} errors and ${warings} warings in ${files} files. `);
+        output.push('Please fix them.');
+    }
+
+    process.stdout.write('\n' + output.join('') + '\n');
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,78 @@
+{
+  "name": "fecs",
+  "version": "1.5.5",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+    },
+    "ansi-styles": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+    },
+    "babel-code-frame": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+      "requires": {
+        "chalk": "1.1.3",
+        "esutils": "2.0.2",
+        "js-tokens": "3.0.2"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
+        }
+      }
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+    },
+    "esutils": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+    },
+    "has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
+    },
+    "js-tokens": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
+    },
+    "strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
+    },
+    "supports-color": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   },
   "homepage": "https://github.com/ecomfe/fecs",
   "dependencies": {
+    "babel-code-frame": "^6.26.0",
     "babel-eslint": "^8.0.1",
     "chalk": "^2.1.0",
     "csscomb": "^4.2.0",


### PR DESCRIPTION
eslint有[codeframe](https://eslint.org/docs/user-guide/formatters/#codeframe)的format，可以更友好的给开发者提示错误的位置，效果截图如下，该pr是我的简单实现：

![codeframe](https://user-images.githubusercontent.com/4426142/36827718-3cd76714-1d50-11e8-904f-7b6811d9d8b4.png)
