### PR TITLE
ES 版本适配 & 配置 root 属性

### DIFF
--- a/lib/js/checker.js
+++ b/lib/js/checker.js
@@ -44,6 +44,12 @@ checker.check = function (contents, path, cliOptions) {
 
     try {
         var ecmaVersion = cliOptions.es;
+
+        // 优先使用配置文件里的 ES 版本设置
+        if (config.parserOptions && config.parserOptions.ecmaVersion) {
+            ecmaVersion = config.parserOptions.ecmaVersion;
+        }
+
         if (ecmaVersion < 6) {
             config = util.mix(
                 config,

--- a/lib/reporter/baidu/index.js
+++ b/lib/reporter/baidu/index.js
@@ -237,8 +237,15 @@ var baidu = {
         var rule = maps.javascript[code];
         var desc = error.message.replace(BAIDU_CODE_REG, '');
         if (rule) {
-            level.warn = rule.level < 2 ? 1 : 0;
-            desc = rule.desc;
+
+            // 一些规范外的其他 eslint 规则， 配置的 warn 会被误判为 error， 这里做下判断
+            if (code === '998' && error.origin && error.origin.severity === 1) {
+                level.warn = 1;
+            }
+            else {
+                level.warn = rule.level < 2 ? 1 : 0;
+                desc = rule.desc;
+            }
         }
         else {
             code = '999';

--- a/lib/util.js
+++ b/lib/util.js
@@ -45,6 +45,7 @@ exports.getConfig = function (key, filepath, defaults, force) {
     if (!localRcloader || force) {
 
         localRcloader = new Manis({
+            enableRoot: true, // 支持 root 配置属性
             files: [
                 CONFIG_NAME,
                 {name: PACKAGE_NAME, get: 'fecs'},


### PR DESCRIPTION
- 优先使用配置文件里的 ES 版本设置 
- 配置文件支持 root 属性
- 修复将很多 eslint 的 warn 误判为 error 的 bug